### PR TITLE
Set a block height to change chainid to prevent conflict with Acala Network

### DIFF
--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -286,7 +286,7 @@ func (ks *KeyStore) SignTx(a accounts.Account, tx *types.Transaction, chainID *b
 	// Depending on the presence of the chain ID, sign with EIP155 or homestead
 	if chainID != nil {
 		//return types.SignTx(tx, types.NewEIP155Signer(chainID), unlockedKey.PrivateKey)
-		return types.SignTx(tx, types.NewEIP155Signer(big.NewInt(787)), unlockedKey.PrivateKey)
+		return types.SignTx(tx, types.NewEIP155Signer(big.NewInt(707)), unlockedKey.PrivateKey)
 	}
 	return types.SignTx(tx, types.HomesteadSigner{}, unlockedKey.PrivateKey)
 }

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -264,7 +264,7 @@ func NewTxPool(config TxPoolConfig, chainconfig *params.ChainConfig, chain block
 		chainconfig: chainconfig,
 		chain:       chain,
 		//signer:          types.NewEIP155Signer(chainconfig.ChainID),
-		signer:          types.NewEIP155Signer(big.NewInt(787)),
+		signer:          types.NewEIP155Signer(big.NewInt(707)),
 		pending:         make(map[common.Address]*txList),
 		queue:           make(map[common.Address]*txList),
 		beats:           make(map[common.Address]time.Time),

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -42,6 +42,8 @@ type sigCache struct {
 func MakeSigner(config *params.ChainConfig, blockNumber *big.Int) Signer {
 	var signer Signer
 	switch {
+	case config.IsLakeKawaguchi(blockNumber):
+		signer = NewEIP155Signer(big.NewInt(707))
 	case config.IsDevethFork(blockNumber):
 		signer = NewEIP155Signer(big.NewInt(787))
 	case config.IsCheapFork(blockNumber):

--- a/eth/api.go
+++ b/eth/api.go
@@ -70,7 +70,9 @@ func (api *PublicEthereumAPI) Hashrate() hexutil.Uint64 {
 func (api *PublicEthereumAPI) ChainId() hexutil.Uint64 {
 	chainID := new(big.Int)
 	if config := api.e.blockchain.Config(); config.IsEIP155(api.e.blockchain.CurrentBlock().Number()) {
-		if config := api.e.blockchain.Config(); config.IsDevethFork(api.e.blockchain.CurrentBlock().Number()) {
+		if config := api.e.blockchain.Config(); config.IsLakeKawaguchi(api.e.blockchain.CurrentBlock().Number()) {
+			chainID = big.NewInt(707)
+		} else if config := api.e.blockchain.Config(); config.IsDevethFork(api.e.blockchain.CurrentBlock().Number()) {
 			chainID = big.NewInt(787)
 		} else if config := api.e.blockchain.Config(); config.IsCheapFork(api.e.blockchain.CurrentBlock().Number()) {
 			// think slot machine

--- a/params/bootnodes.go
+++ b/params/bootnodes.go
@@ -22,8 +22,9 @@ import "github.com/ethereum/go-ethereum/common"
 // the main Ethereum network.
 var MainnetBootnodes = []string{
 	// devEthereum Foundation Go Bootnodes
-	"enode://fe80a20a82dbe6cf01ecc5fa6b2517c5b6e7036144f7be0b619ce96abf92157dd57379e16aa2c0ff77bd338abfbab68ba37aefcc01a354ea57c7002c943b874e@84.251.170.99:30303",
+	"enode://fe80a20a82dbe6cf01ecc5fa6b2517c5b6e7036144f7be0b619ce96abf92157dd57379e16aa2c0ff77bd338abfbab68ba37aefcc01a354ea57c7002c943b874e@84.251.170.99:64373",
 	"enode://f4618108dd208c163e759feed2c8948ff11a770a31f2d3dc126b5060f34bdf1320352a9588cce6628b02950c5a514241228cf8d277794819549635b6c0e3d6b8@148.251.21.109:30303",
+	"enode://87129f686011c1db79e8c5537689efc98ff2e7d06365ffeb52e7b814b37f9ced3f887aa06325cde06d14699877cd41f828c2d825d2556ae9b4144dedf0b3d848@3.239.59.55:30303",
 }
 
 // RopstenBootnodes are the enode URLs of the P2P bootstrap nodes running on the

--- a/params/config.go
+++ b/params/config.go
@@ -71,6 +71,7 @@ var (
 		MuirGlacierBlock:    big.NewInt(9200000),
 		CheapForkBlock:      big.NewInt(11818960),
 		DevethForkBlock:     big.NewInt(11932937),
+		LakeKawaguchiBlock:  big.NewInt(11937832),
 		Ethash:              new(EthashConfig),
 	}
 
@@ -242,16 +243,16 @@ var (
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, new(EthashConfig), nil, nil, nil}
+	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, new(EthashConfig), nil, nil, nil, nil}
 
 	// AllCliqueProtocolChanges contains every protocol change (EIPs) introduced
 	// and accepted by the Ethereum core developers into the Clique consensus.
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, nil, &CliqueConfig{Period: 0, Epoch: 30000}, nil, nil}
+	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, nil, &CliqueConfig{Period: 0, Epoch: 30000}, nil, nil, nil}
 
-	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, new(EthashConfig), nil, nil, nil}
+	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, new(EthashConfig), nil, nil, nil, nil}
 	TestRules       = TestChainConfig.Rules(new(big.Int))
 )
 
@@ -330,8 +331,9 @@ type ChainConfig struct {
 	Ethash *EthashConfig `json:"ethash,omitempty"`
 	Clique *CliqueConfig `json:"clique,omitempty"`
 
-	CheapForkBlock  *big.Int `json:"cheapForkBlock,omitempty"`  // nil = no fork, 0 = already activated
-	DevethForkBlock *big.Int `json:"devethForkBlock,omitempty"` // nil = no fork, 0 = already activated
+	CheapForkBlock     *big.Int `json:"cheapForkBlock,omitempty"`     // nil = no fork, 0 = already activated
+	DevethForkBlock    *big.Int `json:"devethForkBlock,omitempty"`    // nil = no fork, 0 = already activated
+	LakeKawaguchiBlock *big.Int `json:"lakeKawaguchiBlock,omitempty"` // nil = no fork, 0 = already activated
 }
 
 // EthashConfig is the consensus engine configs for proof-of-work based sealing.
@@ -428,6 +430,10 @@ func (c *ChainConfig) IsCheapFork(num *big.Int) bool {
 
 func (c *ChainConfig) IsDevethFork(num *big.Int) bool {
 	return isForked(c.DevethForkBlock, num)
+}
+
+func (c *ChainConfig) IsLakeKawaguchi(num *big.Int) bool {
+	return isForked(c.LakeKawaguchiBlock, num)
 }
 
 // IsPetersburg returns whether num is either


### PR DESCRIPTION
- Set a block height (11937832) to change the chainid to 707 in order to not conflict with Acala Network (787)
- Change bootnodes